### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-package.yml
+++ b/.github/workflows/validate-package.yml
@@ -1,5 +1,10 @@
 name: Validate Package
 
+permissions:
+  contents: read
+  packages: write
+  actions: write
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/nitish-raj/searxng-mcp-bridge/security/code-scanning/2](https://github.com/nitish-raj/searxng-mcp-bridge/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are necessary:
- `contents: read` for accessing the repository's contents.
- `packages: write` for performing the `npm publish --dry-run` operation.
- `actions: write` for uploading artifacts.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
