### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches: [ main ]
   workflow_dispatch:  # Allow manual triggering
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nitish-raj/searxng-mcp-bridge/security/code-scanning/1](https://github.com/nitish-raj/searxng-mcp-bridge/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's operations, the following permissions are appropriate:
- `contents: read` for accessing the repository's contents during the `actions/checkout@v4` step.
- No additional permissions are required for the other steps, as they do not interact with issues, pull requests, or other repository features.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the `build` job to limit its scope. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
